### PR TITLE
feat: move to redis-py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
         types: [text]
         stages: [commit, push, manual]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v2.7.1
     hooks:
       - id: prettier
   - repo: https://github.com/rhysd/actionlint

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Inspired by
 
 ## Main Dependencies
 
-- [Python +3.6](https://www.python.org)
-- [aioredis 2.0](https://aioredis.readthedocs.io/en/latest/)
+- [Python +3.7](https://www.python.org)
+- [redis-py <4.3.0](https://github.com/redis/redis-py)
 - [pydantic](https://github.com/samuelcolvin/pydantic/)
 
 ## Getting Started

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,21 +21,6 @@ yarl = ">=1.0,<2.0"
 speedups = ["aiodns", "brotli", "cchardet"]
 
 [[package]]
-name = "aioredis"
-version = "2.0.1"
-description = "asyncio (PEP 3156) Redis support"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-async-timeout = "*"
-typing-extensions = "*"
-
-[package.extras]
-hiredis = ["hiredis (>=1.0)"]
-
-[[package]]
 name = "aiosignal"
 version = "1.2.0"
 description = "aiosignal: a list of registered asynchronous callbacks"
@@ -276,7 +261,7 @@ python-versions = ">=3.6,<4.0"
 name = "deprecated"
 version = "1.2.13"
 description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -582,7 +567,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "importlib-metadata"
 version = "4.2.0"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -713,7 +698,7 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -900,7 +885,7 @@ testutil = ["gitpython (>3)"]
 name = "pyparsing"
 version = "3.0.9"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6.8"
 
@@ -1077,7 +1062,7 @@ python-versions = ">=3.6"
 name = "redis"
 version = "4.3.4"
 description = "Python client for Redis database and key-value store"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -1534,7 +1519,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 name = "wrapt"
 version = "1.14.1"
 description = "Module for decorators, wrappers and monkey patching."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
@@ -1579,7 +1564,7 @@ typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 name = "zipp"
 version = "3.8.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -1594,7 +1579,7 @@ fastapi-crudrouter = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "c2d9175a968bb90d290159ee44bca10472855907c38203f90aa8e9d93f7ebbeb"
+content-hash = "602266b1c997c1055845e82c281a014dad857da4020bfa9284a728a7ee31585d"
 
 [metadata.files]
 aiohttp = [
@@ -1670,10 +1655,6 @@ aiohttp = [
     {file = "aiohttp-3.8.1-cp39-cp39-win32.whl", hash = "sha256:7187a76598bdb895af0adbd2fb7474d7f6025d170bc0a1130242da817ce9e7d1"},
     {file = "aiohttp-3.8.1-cp39-cp39-win_amd64.whl", hash = "sha256:1c182cb873bc91b411e184dab7a2b664d4fea2743df0e4d57402f7f3fa644bac"},
     {file = "aiohttp-3.8.1.tar.gz", hash = "sha256:fc5471e1a54de15ef71c1bc6ebe80d4dc681ea600e68bfd1cbce40427f0b7578"},
-]
-aioredis = [
-    {file = "aioredis-2.0.1-py3-none-any.whl", hash = "sha256:9ac0d0b3b485d293b8ca1987e6de8658d7dafcca1cddfcd1d506cae8cdebfdd6"},
-    {file = "aioredis-2.0.1.tar.gz", hash = "sha256:eaa51aaf993f2d71f54b70527c440437ba65340588afeb786cd87c55c89cd98e"},
 ]
 aiosignal = [
     {file = "aiosignal-1.2.0-py3-none-any.whl", hash = "sha256:26e62109036cd181df6e6ad646f91f0dcfd05fe16d0cb924138ff2ab75d64e3a"},

--- a/pydantic_aioredis/abstract.py
+++ b/pydantic_aioredis/abstract.py
@@ -14,7 +14,6 @@ from typing import Optional
 from typing import Union
 from uuid import UUID
 
-import aioredis
 from pydantic import BaseModel
 from pydantic.fields import SHAPE_DEFAULTDICT
 from pydantic.fields import SHAPE_DICT
@@ -26,6 +25,7 @@ from pydantic.fields import SHAPE_SET
 from pydantic.fields import SHAPE_TUPLE
 from pydantic.fields import SHAPE_TUPLE_ELLIPSIS
 from pydantic_aioredis.config import RedisConfig
+from redis import asyncio as aioredis
 
 # JSON_DUMP_SHAPES are object types that are serialized to JSON using json.dumps
 JSON_DUMP_SHAPES = (

--- a/pydantic_aioredis/store.py
+++ b/pydantic_aioredis/store.py
@@ -3,10 +3,10 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 
-import aioredis
 from pydantic_aioredis.abstract import _AbstractStore
 from pydantic_aioredis.config import RedisConfig
 from pydantic_aioredis.model import Model
+from redis import asyncio as aioredis
 
 
 class Store(_AbstractStore):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ Changelog = "https://github.com/andrewthetechie/pydantic-aioredis/releases"
 [tool.poetry.dependencies]
 python = "^3.7"
 pydantic = "^1.8.2"
-aioredis = "^2.0.0"
+redis = "^4.3.4"
 
 [tool.poetry.extras]
 FastAPI= ['fastapi>=0.63.0']


### PR DESCRIPTION
Fixes https://github.com/andrewthetechie/pydantic-aioredis/issues/215

aioredis-py has been migrated into redis-py as of the 4.2.0 release
line.

This replaces aioredis-py with redis-py ^4.34.0