### PR TITLE
ci: tests without redislite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pydantic-aioredis
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 A simple declarative ORM for Redis, using aioredis. Use your Pydantic
@@ -19,7 +19,8 @@ Inspired by
     <img alt="GitHub release (latest by date)" src="https://img.shields.io/github/v/release/andrewthetechie/pydantic-aioredis?label=Latest%20Release">
     <br />
     <a href="https://github.com/andrewthetechie/pydantic-aioredis/issues"><img src="https://img.shields.io/github/issues/andrewthetechie/pydantic-aioredis" /></a>
-    <img alt="GitHub Workflow Status Test and Lint (branch)" src="https://img.shields.io/github/workflow/status/andrewthetechie/pydantic-aioredis/Tests/main?label=Tests">
+    <img alt="GitHub Workflow Status Test and Lint (branch)" src="https://img.shields.io/github/actions/workflow/status/andrewthetechie/pydantic-aioredis/tests.yml?branch=main">
+    <img alt="Contributors" src="https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)">
     <br />
     <a href="https://pypi.org/project/pydantic-aioredis" target="_blank">
         <img src="https://img.shields.io/pypi/v/pydantic-aioredis" alt="Package version">

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,7 +37,7 @@ nox.options.sessions = (
 )
 mypy_type_packages = ()
 pyproject = toml.load("pyproject.toml")
-test_requirements = pyproject["tool"]["poetry"]["dev-dependencies"].keys()
+test_requirements = pyproject["tool"]["poetry"]["group"]["dev"]["dependencies"].keys()
 
 
 def activate_virtualenv_in_precommit_hooks(session: Session) -> None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -251,6 +251,14 @@ optional = false
 python-versions = ">=3.6,<4.0"
 
 [[package]]
+name = "decorator"
+version = "5.1.1"
+description = "Decorators for Humans"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "dill"
 version = "0.3.6"
 description = "serialize all of python"
@@ -314,6 +322,23 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
 testing = ["pre-commit"]
+
+[[package]]
+name = "fakeredis"
+version = "2.2.0"
+description = "Fake implementation of redis API for testing purposes."
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+jsonpath-ng = {version = ">=1.5,<2.0", optional = true, markers = "extra == \"json\""}
+redis = "<4.5"
+sortedcontainers = ">=2.4.0,<3.0.0"
+
+[package.extras]
+json = ["jsonpath-ng (>=1.5,<2.0)"]
+lua = ["lupa (>=1.14,<2.0)"]
 
 [[package]]
 name = "fastapi"
@@ -587,6 +612,19 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "jsonpath-ng"
+version = "1.5.3"
+description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+decorator = "*"
+ply = "*"
+six = "*"
+
+[[package]]
 name = "lazy-object-proxy"
 version = "1.8.0"
 description = "A fast and thorough lazy object proxy."
@@ -743,6 +781,14 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "ply"
+version = "3.11"
+description = "Python Lex & Yacc"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pre-commit"
 version = "2.20.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -770,17 +816,6 @@ python-versions = ">=3.7"
 [package.dependencies]
 "ruamel.yaml" = ">=0.15"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-
-[[package]]
-name = "psutil"
-version = "5.9.4"
-description = "Cross-platform lib for process and system monitoring in Python."
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[package.extras]
-test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "py"
@@ -1052,19 +1087,6 @@ hiredis = ["hiredis (>=1.0.0)"]
 ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
 
 [[package]]
-name = "redislite"
-version = "6.2.805324"
-description = "Redis built into a python package"
-category = "dev"
-optional = false
-python-versions = ">=3.7.0"
-
-[package.dependencies]
-psutil = "*"
-redis = "*"
-setuptools = ">38.0"
-
-[[package]]
 name = "reorder-python-imports"
 version = "3.9.0"
 description = "Tool for reordering python imports"
@@ -1215,6 +1237,14 @@ python-versions = ">=3.7"
 name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
 category = "dev"
 optional = false
 python-versions = "*"
@@ -1573,7 +1603,7 @@ fastapi-crudrouter = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "ca0fa9f5ecb712e2e34654c447a244f67f1bf203a0ee7993c0fa718ca98f16d7"
+content-hash = "0d2e8c0691c926e853bc5cc90754e19c23453bdab157ebee11de870632c4d595"
 
 [metadata.files]
 aiohttp = [
@@ -1799,6 +1829,10 @@ darglint = [
     {file = "darglint-1.8.1-py3-none-any.whl", hash = "sha256:5ae11c259c17b0701618a20c3da343a3eb98b3bc4b5a83d31cdd94f5ebdced8d"},
     {file = "darglint-1.8.1.tar.gz", hash = "sha256:080d5106df149b199822e7ee7deb9c012b49891538f14a11be681044f0bb20da"},
 ]
+decorator = [
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
 dill = [
     {file = "dill-0.3.6-py3-none-any.whl", hash = "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0"},
     {file = "dill-0.3.6.tar.gz", hash = "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"},
@@ -1822,6 +1856,10 @@ exceptiongroup = [
 execnet = [
     {file = "execnet-1.9.0-py2.py3-none-any.whl", hash = "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"},
     {file = "execnet-1.9.0.tar.gz", hash = "sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5"},
+]
+fakeredis = [
+    {file = "fakeredis-2.2.0-py3-none-any.whl", hash = "sha256:1ac7adf04dcbf8f9886add5972018e0e42781ee772fbaa0a573350cd4e4c66f7"},
+    {file = "fakeredis-2.2.0.tar.gz", hash = "sha256:dacdede58b0e682d5dc6176518858b6933c3d529ec18270f162ad5aaf97f5769"},
 ]
 fastapi = [
     {file = "fastapi-0.88.0-py3-none-any.whl", hash = "sha256:263b718bb384422fe3d042ffc9a0c8dece5e034ab6586ff034f6b4b1667c3eee"},
@@ -1978,6 +2016,11 @@ isort = [
 Jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
     {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
+]
+jsonpath-ng = [
+    {file = "jsonpath-ng-1.5.3.tar.gz", hash = "sha256:a273b182a82c1256daab86a313b937059261b5c5f8c4fa3fc38b882b344dd567"},
+    {file = "jsonpath_ng-1.5.3-py2-none-any.whl", hash = "sha256:f75b95dbecb8a0f3b86fd2ead21c2b022c3f5770957492b9b6196ecccfeb10aa"},
+    {file = "jsonpath_ng-1.5.3-py3-none-any.whl", hash = "sha256:292a93569d74029ba75ac2dc3d3630fc0e17b2df26119a165fa1d498ca47bf65"},
 ]
 lazy-object-proxy = [
     {file = "lazy-object-proxy-1.8.0.tar.gz", hash = "sha256:c219a00245af0f6fa4e95901ed28044544f50152840c5b6a3e7b2568db34d156"},
@@ -2193,6 +2236,10 @@ pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
+ply = [
+    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
+    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
+]
 pre-commit = [
     {file = "pre_commit-2.20.0-py2.py3-none-any.whl", hash = "sha256:51a5ba7c480ae8072ecdb6933df22d2f812dc897d5fe848778116129a681aac7"},
     {file = "pre_commit-2.20.0.tar.gz", hash = "sha256:a978dac7bc9ec0bcee55c18a277d553b0f419d259dadb4b9418ff2d00eb43959"},
@@ -2200,22 +2247,6 @@ pre-commit = [
 pre-commit-hooks = [
     {file = "pre_commit_hooks-4.4.0-py2.py3-none-any.whl", hash = "sha256:fc8837335476221ccccda3d176ed6ae29fe58753ce7e8b7863f5d0f987328fc6"},
     {file = "pre_commit_hooks-4.4.0.tar.gz", hash = "sha256:7011eed8e1a25cde94693da009cba76392194cecc2f3f06c51a44ea6ad6c2af9"},
-]
-psutil = [
-    {file = "psutil-5.9.4-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c1ca331af862803a42677c120aff8a814a804e09832f166f226bfd22b56feee8"},
-    {file = "psutil-5.9.4-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:68908971daf802203f3d37e78d3f8831b6d1014864d7a85937941bb35f09aefe"},
-    {file = "psutil-5.9.4-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:3ff89f9b835100a825b14c2808a106b6fdcc4b15483141482a12c725e7f78549"},
-    {file = "psutil-5.9.4-cp27-cp27m-win32.whl", hash = "sha256:852dd5d9f8a47169fe62fd4a971aa07859476c2ba22c2254d4a1baa4e10b95ad"},
-    {file = "psutil-5.9.4-cp27-cp27m-win_amd64.whl", hash = "sha256:9120cd39dca5c5e1c54b59a41d205023d436799b1c8c4d3ff71af18535728e94"},
-    {file = "psutil-5.9.4-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:6b92c532979bafc2df23ddc785ed116fced1f492ad90a6830cf24f4d1ea27d24"},
-    {file = "psutil-5.9.4-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:efeae04f9516907be44904cc7ce08defb6b665128992a56957abc9b61dca94b7"},
-    {file = "psutil-5.9.4-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:54d5b184728298f2ca8567bf83c422b706200bcbbfafdc06718264f9393cfeb7"},
-    {file = "psutil-5.9.4-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:16653106f3b59386ffe10e0bad3bb6299e169d5327d3f187614b1cb8f24cf2e1"},
-    {file = "psutil-5.9.4-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54c0d3d8e0078b7666984e11b12b88af2db11d11249a8ac8920dd5ef68a66e08"},
-    {file = "psutil-5.9.4-cp36-abi3-win32.whl", hash = "sha256:149555f59a69b33f056ba1c4eb22bb7bf24332ce631c44a319cec09f876aaeff"},
-    {file = "psutil-5.9.4-cp36-abi3-win_amd64.whl", hash = "sha256:fd8522436a6ada7b4aad6638662966de0d61d241cb821239b2ae7013d41a43d4"},
-    {file = "psutil-5.9.4-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:6001c809253a29599bc0dfd5179d9f8a5779f9dffea1da0f13c53ee568115e1e"},
-    {file = "psutil-5.9.4.tar.gz", hash = "sha256:3d7f9739eb435d4b1338944abe23f49584bde5395f27487d2ee25ad9a8774a62"},
 ]
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
@@ -2373,24 +2404,6 @@ redis = [
     {file = "redis-4.4.0-py3-none-any.whl", hash = "sha256:cae3ee5d1f57d8caf534cd8764edf3163c77e073bdd74b6f54a87ffafdc5e7d9"},
     {file = "redis-4.4.0.tar.gz", hash = "sha256:7b8c87d19c45d3f1271b124858d2a5c13160c4e74d4835e28273400fa34d5228"},
 ]
-redislite = [
-    {file = "redislite-6.2.805324-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0f0642a5a6b79d086260e2ce42a95744dc5e5339f571ac149705730de8f68be9"},
-    {file = "redislite-6.2.805324-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6abef5810940eca315b8c90f45b0ebda8e76c0a0ea6e9f606b8166f01a082b1"},
-    {file = "redislite-6.2.805324-cp311-cp311-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0b3f202cee43bda332f97615ecf4a7c3b2b91c9ab28abf0494a21f6829d19101"},
-    {file = "redislite-6.2.805324-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a704fdfb74b4b1711f86b98deeb0627ed7bbdf21653e48146d9369cda2fc40c4"},
-    {file = "redislite-6.2.805324-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:09989c29788e2a4ab0c946869582451f6a46b4099a17482560d990250ffad696"},
-    {file = "redislite-6.2.805324-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ad793d9b45d2e77d36753b695391c1a9e77a84b1782f7ea5d42fb5af3bbe86a"},
-    {file = "redislite-6.2.805324-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ba35f7600d119a1db1cbae77c0591b8e0feb351689117c68c23bc5f34d3442af"},
-    {file = "redislite-6.2.805324-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4904fe27211637c17dd98b4547cc6de4cacf231b394b5174d7acca38409db5c4"},
-    {file = "redislite-6.2.805324-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bdd673e51b42d515b273518c4670d2d94d54542baa67b2d4c8951e47e05cd349"},
-    {file = "redislite-6.2.805324-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fbb1433b4a2d88889b550bd08c6885a58446d204c6ee031a5a2fdee83620f46"},
-    {file = "redislite-6.2.805324-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:79f4540aa4c5f6cd85370a504b6610ef6995775307389559ad4001f61949c229"},
-    {file = "redislite-6.2.805324-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:731b6d239f67f8fc9e3d801dca26269291b94be772c37bc2b65a884c9d79138e"},
-    {file = "redislite-6.2.805324-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4640ed4533c176b3b1fab4592af39d3fab6423843c7634b6b5aba980dfc5d578"},
-    {file = "redislite-6.2.805324-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e86ef58c491a6dc0c04fad86c286bb43edc128b26006ef90b2b49ed1d38e089"},
-    {file = "redislite-6.2.805324-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7723317952715b7fa5e21d14ef3cf4d5a18f43f828e04b39712fa8d13d2274ff"},
-    {file = "redislite-6.2.805324.tar.gz", hash = "sha256:603b28bcdfdbe45edfe0046dc99b0fcbe3d5c533d1b7e5d9c3ff6208a656e7f1"},
-]
 reorder-python-imports = [
     {file = "reorder_python_imports-3.9.0-py2.py3-none-any.whl", hash = "sha256:3f9c16e8781f54c944756d0d1eb34a8c863554f7a4eb3693f574fe19b1a29b56"},
     {file = "reorder_python_imports-3.9.0.tar.gz", hash = "sha256:49292ed537829a6bece9fb3746fc1bbe98f52643be5de01a4e13680268a5b0ec"},
@@ -2472,6 +2485,10 @@ sniffio = [
 snowballstemmer = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
+]
+sortedcontainers = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 soupsieve = [
     {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ FastAPI= ['fastapi>=0.63.0']
 fastapi-crudrouter=['fastapi-crudrouter>=0.8.4']
 
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"
 coverage = {extras = ["toml"], version = "^6.5"}
 safety = "^2.3.1"
@@ -70,13 +70,11 @@ httpx = "^0.23.0"
 pytest-env = "^0.8.1"
 pytest-mockservers = "^0.6.0"
 pytest-xdist = "^3.1.0"
-redislite = "^6.0.674960"
 tox = "^3.27.0"
 pylint = "^2.13.9"
 setuptools-git-versioning = "^1.13.1"
-
-[tool.poetry.group.dev.dependencies]
 bandit = "^1.7.4"
+fakeredis = {extras = ["json"], version = "2.2.0"}
 
 [tool.coverage.paths]
 source = ["pydantic_aioredis", "*/site-packages"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,30 +1,20 @@
 import pytest
 import pytest_asyncio
-import redislite
+from fakeredis.aioredis import FakeRedis
 from pydantic_aioredis.config import RedisConfig
 from pydantic_aioredis.model import Model
 from pydantic_aioredis.store import Store
 
 
 @pytest_asyncio.fixture()
-def redis_server(unused_tcp_port):
-    """Sets up a fake redis server we can use for tests"""
-    instance = redislite.Redis(serverconfig={"port": unused_tcp_port})
-
-    yield unused_tcp_port
-
-    instance.close()
-    instance.shutdown()
-
-
-@pytest_asyncio.fixture()
-async def redis_store(redis_server):
+async def redis_store():
     """Sets up a redis store using the redis_server fixture and adds the book model to it"""
     store = Store(
         name="sample",
-        redis_config=RedisConfig(port=redis_server, db=1),  # nosec
+        redis_config=RedisConfig(port=1024, db=1),  # nosec
         life_span_in_seconds=3600,
     )
+    store.redis_store = FakeRedis(decode_responses=True)
     yield store
     await store.redis_store.flushall()
 

--- a/test/ext/FastAPI/test_ext_fastapi.py
+++ b/test/ext/FastAPI/test_ext_fastapi.py
@@ -2,6 +2,7 @@ from typing import List
 
 import pytest
 import pytest_asyncio
+from fakeredis.aioredis import FakeRedis
 from fastapi import FastAPI
 from httpx import AsyncClient
 from pydantic_aioredis.config import RedisConfig
@@ -15,12 +16,13 @@ class Model(FastAPIModel):
 
 
 @pytest_asyncio.fixture()
-async def test_app(redis_server):
+async def test_app():
     store = Store(
         name="sample",
-        redis_config=RedisConfig(port=redis_server, db=1),  # nosec
+        redis_config=RedisConfig(port=1024, db=1),  # nosec
         life_span_in_seconds=3600,
     )
+    store.redis_store = FakeRedis(decode_responses=True)
     store.register_model(Model)
 
     app = FastAPI()

--- a/test/ext/FastAPI/test_ext_fastapi_crudrouter.py
+++ b/test/ext/FastAPI/test_ext_fastapi_crudrouter.py
@@ -2,6 +2,7 @@ from typing import List
 
 import pytest
 import pytest_asyncio
+from fakeredis.aioredis import FakeRedis
 from fastapi import FastAPI
 from httpx import AsyncClient
 from pydantic_aioredis import Model as PAModel
@@ -24,12 +25,13 @@ class ModelNoSync(PAModel):
 
 
 @pytest_asyncio.fixture()
-async def test_app(redis_server):
+async def test_app():
     store = Store(
         name="sample",
-        redis_config=RedisConfig(port=redis_server, db=1),  # nosec
+        redis_config=RedisConfig(port=1024, db=1),  # nosec
         life_span_in_seconds=3600,
     )
+    store.redis_store = FakeRedis(decode_responses=True)
     store.register_model(Model)
 
     app = FastAPI()
@@ -157,13 +159,14 @@ async def test_crudrouter_put_200(test_app, test_models):
 
 
 @pytest.mark.asyncio
-async def test_crudrouter_put_200_no_autosync(redis_server):
+async def test_crudrouter_put_200_no_autosync():
     """Tests that crudrouter put will 404 when no instance exists"""
     store = Store(
         name="sample",
-        redis_config=RedisConfig(port=redis_server, db=1),  # nosec
+        redis_config=RedisConfig(port=1024, db=1),  # nosec
         life_span_in_seconds=3600,
     )
+    store.redis_store = FakeRedis(decode_responses=True)
     store.register_model(ModelNoSync)
 
     app = FastAPI()

--- a/test/test_pydantic_aioredis.py
+++ b/test/test_pydantic_aioredis.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
+from fakeredis.aioredis import FakeRedis
 from pydantic_aioredis.config import RedisConfig
 from pydantic_aioredis.model import Model
 from pydantic_aioredis.store import Store
@@ -134,13 +135,14 @@ test_models_with_fullcustom = [
 
 
 @pytest_asyncio.fixture()
-async def redis_store(redis_server):
+async def redis_store():
     """Sets up a redis store using the redis_server fixture and adds the book model to it"""
     store = Store(
         name="sample",
-        redis_config=RedisConfig(port=redis_server, db=1),  # nosec
+        redis_config=RedisConfig(port=1024, db=1),  # nosec
         life_span_in_seconds=3600,
     )
+    store.redis_store = FakeRedis(decode_responses=True)
     store.register_model(Book)
     store.register_model(ExtendedBook)
     store.register_model(ModelWithNone)

--- a/test/test_union_typing.py
+++ b/test/test_union_typing.py
@@ -42,9 +42,10 @@ async def test_float_int_assign_inside(redis_store):
     assert isinstance(instance.float_int, int)
 
 
+@pytest.mark.asyncio
 @pytest.mark.union_test
 @pytest.mark.xfail
-def test_float_int_assign_inside_pydantic_only():
+async def test_float_int_assign_inside_pydantic_only():
     class FloatIntTestPydantic(BaseModel):
 
         key: str
@@ -60,8 +61,9 @@ def test_float_int_assign_inside_pydantic_only():
     assert isinstance(instance.float_int, int)
 
 
+@pytest.mark.asyncio
 @pytest.mark.union_test
-def test_float_int_assign_after():
+async def test_float_int_assign_after():
     key = "test_float_int_assign_after"
     instance = FloatIntTest(
         key=key,
@@ -90,9 +92,10 @@ async def test_int_float_assign_inside(redis_store):
     assert isinstance(instance.int_float, float)
 
 
+@pytest.mark.asyncio
 @pytest.mark.union_test
 @pytest.mark.xfail
-def test_int_float_assign_inside_pydantic_only():
+async def test_int_float_assign_inside_pydantic_only():
     class IntFloatTestPydantic(BaseModel):
         key: str
         int_float: Union[int, float]  # fails
@@ -108,8 +111,9 @@ def test_int_float_assign_inside_pydantic_only():
     assert isinstance(instance.int_float, float)
 
 
+@pytest.mark.asyncio
 @pytest.mark.union_test
-def test_int_float_assign_after():
+async def test_int_float_assign_after():
     key = "test_int_float_assign_after"
     instance = IntFloatTest(
         key=key,


### PR DESCRIPTION
Thanks to @gtmanfred for invaluable debugging help and suggestions on how to improve testing.

Redislite worked well, but it spun up an actual redis server for each test. This caused a bunch of flakiness.

This PR moves to using fakeredis, which mocks redis entirely in python without spinning up an external redis service. Tests are faster and more reliable and use less system resources