### PR TITLE
fix: cleanup serializer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,8 @@ jobs:
             ${{ steps.pre-commit-cache.outputs.result }}-
 
       - name: Run Nox
+        env:
+          HYPOTHESIS_PROFILE: ci
         run: |
           nox --force-color --python=${{ matrix.python }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage.xml
 __pycache__/
 examples/benchmarks/.benchmarks
 examples/benchmarks/.coverage
+.hypothesis

--- a/poetry.lock
+++ b/poetry.lock
@@ -533,6 +533,35 @@ http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (>=1.0.0,<2.0.0)"]
 
 [[package]]
+name = "hypothesis"
+version = "6.61.0"
+description = "A library for property-based testing"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+attrs = ">=19.2.0"
+exceptiongroup = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+sortedcontainers = ">=2.1.0,<3.0.0"
+
+[package.extras]
+all = ["backports.zoneinfo (>=0.2.1)", "black (>=19.10b0)", "click (>=7.0)", "django (>=3.2)", "dpcontracts (>=0.4)", "importlib-metadata (>=3.6)", "lark (>=0.10.1)", "libcst (>=0.3.16)", "numpy (>=1.9.0)", "pandas (>=1.0)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "tzdata (>=2022.7)"]
+cli = ["black (>=19.10b0)", "click (>=7.0)", "rich (>=9.0.0)"]
+codemods = ["libcst (>=0.3.16)"]
+dateutil = ["python-dateutil (>=1.4)"]
+django = ["django (>=3.2)"]
+dpcontracts = ["dpcontracts (>=0.4)"]
+ghostwriter = ["black (>=19.10b0)"]
+lark = ["lark (>=0.10.1)"]
+numpy = ["numpy (>=1.9.0)"]
+pandas = ["pandas (>=1.0)"]
+pytest = ["pytest (>=4.6)"]
+pytz = ["pytz (>=2014.1)"]
+redis = ["redis (>=3.0.0)"]
+zoneinfo = ["backports.zoneinfo (>=0.2.1)", "tzdata (>=2022.7)"]
+
+[[package]]
 name = "identify"
 version = "2.5.10"
 description = "File identification library for Python"
@@ -1603,7 +1632,7 @@ fastapi-crudrouter = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "997163e8112dddaa271f72252b958f4793306e546d9eddd0d55cd14c94bebd18"
+content-hash = "59033ca432adea904a4d113eba5c8a393ddd4402483f9074a996624b437e2387"
 
 [metadata.files]
 aiohttp = [
@@ -1988,6 +2017,10 @@ httpcore = [
 httpx = [
     {file = "httpx-0.23.1-py3-none-any.whl", hash = "sha256:0b9b1f0ee18b9978d637b0776bfd7f54e2ca278e063e3586d8f01cda89e042a8"},
     {file = "httpx-0.23.1.tar.gz", hash = "sha256:202ae15319be24efe9a8bd4ed4360e68fde7b38bcc2ce87088d416f026667d19"},
+]
+hypothesis = [
+    {file = "hypothesis-6.61.0-py3-none-any.whl", hash = "sha256:7bb22d22e35db99d5724bbf5bdc686b46add94a0f228bf1be249c47ec46b9c7f"},
+    {file = "hypothesis-6.61.0.tar.gz", hash = "sha256:fbf7da30aea839d88898f74bcc027f0f997060498a8a7605880688c8a2166215"},
 ]
 identify = [
     {file = "identify-2.5.10-py2.py3-none-any.whl", hash = "sha256:fb7c2feaeca6976a3ffa31ec3236a6911fbc51aec9acc111de2aed99f244ade2"},

--- a/pydantic_aioredis/abstract.py
+++ b/pydantic_aioredis/abstract.py
@@ -2,7 +2,6 @@
 import json
 from datetime import date
 from datetime import datetime
-from enum import Enum
 from ipaddress import IPv4Address
 from ipaddress import IPv4Network
 from ipaddress import IPv6Address
@@ -15,31 +14,8 @@ from typing import Union
 from uuid import UUID
 
 from pydantic import BaseModel
-from pydantic.fields import SHAPE_DEFAULTDICT
-from pydantic.fields import SHAPE_DICT
-from pydantic.fields import SHAPE_FROZENSET
-from pydantic.fields import SHAPE_LIST
-from pydantic.fields import SHAPE_MAPPING
-from pydantic.fields import SHAPE_SEQUENCE
-from pydantic.fields import SHAPE_SET
-from pydantic.fields import SHAPE_TUPLE
-from pydantic.fields import SHAPE_TUPLE_ELLIPSIS
 from pydantic_aioredis.config import RedisConfig
 from redis import asyncio as aioredis
-
-# JSON_DUMP_SHAPES are object types that are serialized to JSON using json.dumps
-JSON_DUMP_SHAPES = (
-    SHAPE_LIST,
-    SHAPE_SET,
-    SHAPE_MAPPING,
-    SHAPE_TUPLE,
-    SHAPE_TUPLE_ELLIPSIS,
-    SHAPE_SEQUENCE,
-    SHAPE_FROZENSET,
-    SHAPE_DICT,
-    SHAPE_DEFAULTDICT,
-    Enum,
-)
 
 # STR_DUMP_SHAPES are object types that are serialized to strings using str(obj)
 # They are stored in redis as strings and rely on pydantic to deserialize them
@@ -113,8 +89,6 @@ class _AbstractModel(BaseModel):
                 continue
             if cls.__fields__[field].type_ not in [str, float, int]:
                 data[field] = json.dumps(data[field], default=cls.json_default)
-            if getattr(cls.__fields__[field], "shape", None) in JSON_DUMP_SHAPES:
-                data[field] = json.dumps(data[field], default=cls.json_default)
             if getattr(cls.__fields__[field], "allow_none", False):
                 if data[field] is None:
                     data[field] = "None"
@@ -132,8 +106,6 @@ class _AbstractModel(BaseModel):
             if field not in columns:
                 continue
             if cls.__fields__[field].type_ not in [str, float, int]:
-                data[field] = json.loads(data[field], object_hook=cls.json_object_hook)
-            if getattr(cls.__fields__[field], "shape", None) in JSON_DUMP_SHAPES:
                 data[field] = json.loads(data[field], object_hook=cls.json_object_hook)
             if getattr(cls.__fields__[field], "allow_none", False):
                 if data[field] == "None":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ pylint = "^2.13.9"
 setuptools-git-versioning = "^1.13.1"
 bandit = "^1.7.4"
 fakeredis = {extras = ["json"], version = "2.2.0"}
+hypothesis = "^6.61.0"
 
 [tool.coverage.paths]
 source = ["pydantic_aioredis", "*/site-packages"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -24,6 +24,7 @@ async def redis_store():
 def pytest_configure(config):
     """Configure our markers"""
     config.addinivalue_line("markers", "union_test: Tests for union types")
+    config.addinivalue_line("markers", "hypothesis: Tests that use hypothesis")
 
 
 @pytest.hookimpl(trylast=True)
@@ -32,3 +33,12 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if inspect.iscoroutinefunction(item.function):
             item.add_marker(pytest.mark.asyncio)
+
+
+import os
+from hypothesis import settings, Verbosity
+
+settings.register_profile("ci", max_examples=5000)
+settings.register_profile("dev", max_examples=100)
+settings.register_profile("debug", max_examples=10, verbosity=Verbosity.verbose)
+settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "dev"))

--- a/test/test_abstract.py
+++ b/test/test_abstract.py
@@ -1,0 +1,76 @@
+"""Test methods in abstract.py. Uses hypothesis"""
+import json
+from datetime import date
+from datetime import datetime
+from ipaddress import IPv4Address
+from ipaddress import IPv6Address
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Union
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic_aioredis.model import Model
+
+
+class SimpleModel(Model):
+    _primary_key_field: str = "test_str"
+    test_str: str
+    test_int: int
+    test_float: float
+    test_date: date
+    test_datetime: datetime
+    test_ip_v4: IPv4Address
+    test_ip_v6: IPv6Address
+    test_list: List
+    test_dict: Dict[str, Union[int, float]]
+    test_tuple: Tuple[str]
+
+
+parameters = [
+    (st.text, [], {}, "test_str", None),
+    (st.integers, [], {}, "test_int", None),
+    (st.floats, [], {"allow_nan": False}, "test_float", None),
+    (st.dates, [], {}, "test_date", lambda x: json.dumps(x.isoformat())),
+    (st.datetimes, [], {}, "test_datetime", lambda x: json.dumps(x.isoformat())),
+    (st.ip_addresses, [], {"v": 4}, "test_ip_v4", lambda x: json.dumps(str(x))),
+    (st.ip_addresses, [], {"v": 6}, "test_ip_v4", lambda x: json.dumps(str(x))),
+    (
+        st.lists,
+        [st.tuples(st.integers(), st.floats())],
+        {},
+        "test_list",
+        lambda x: json.dumps(x),
+    ),
+    (
+        st.dictionaries,
+        [st.text(), st.tuples(st.integers(), st.floats())],
+        {},
+        "test_dict",
+        lambda x: json.dumps(x),
+    ),
+    (st.tuples, [st.text()], {}, "test_tuple", lambda x: json.dumps(x)),
+]
+
+
+@pytest.mark.parametrize(
+    "strategy, strategy_args, strategy_kwargs, model_field, serialize_callable",
+    parameters,
+)
+@given(st.data())
+def test_serialize_partially(
+    strategy, strategy_args, strategy_kwargs, model_field, serialize_callable, data
+):
+    value = data.draw(strategy(*strategy_args, **strategy_kwargs))
+    serialized = SimpleModel.serialize_partially({model_field: value})
+    if serialize_callable is None:
+        assert serialized[model_field] == value
+    else:
+        assert serialized[model_field] == serialize_callable(value)
+
+
+def test_serialize_partially_skip_missing_filed():
+    serialized = SimpleModel.serialize_partially({"unknown": "test"})
+    assert serialized["unknown"] == "test"

--- a/test/test_pydantic_aioredis.py
+++ b/test/test_pydantic_aioredis.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 import pytest
 import pytest_asyncio
 from fakeredis.aioredis import FakeRedis
+from pydantic_aioredis.abstract import _AbstractModel
 from pydantic_aioredis.config import RedisConfig
 from pydantic_aioredis.model import Model
 from pydantic_aioredis.store import Store
@@ -189,6 +190,15 @@ def test_store_model(redis_store):
 
     with pytest.raises(KeyError):
         redis_store.model("Notabook")
+
+
+def test_json_object_hook():
+    class TestObj:
+        def __init__(self, value: str):
+            self.value = value
+
+    test_obj = TestObj("test")
+    assert test_obj.value == _AbstractModel.json_object_hook(test_obj).value
 
 
 parameters = [


### PR DESCRIPTION
serialize_partially and deserialize_partially had a dead code path, using "json dump shapes" to determine to json dump something. However, the first if checking for str, float, or int already handles that.

This dead code was found using hypothesis testing, included in the new tests/test_abstract.py. In the future, I'd like to augment the hardcoded test data in test_pydantic_aioredis with hypothesis data